### PR TITLE
Exports list of locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,6 @@ g.MonthShortByNumber(2) // "Feb"
 #### Adding a new locale
 To add a new locale, there are a few steps to follow. You must first add a new file in the `/locales` folder. This should be named the locale code, e.g. `fr.go`. Inside this file, you need to create a new `LocaleDetails` object and provide the required values for month names, weekday names, ordinal function, etc. Please use one of the existing locales for reference.
 
-After you've created the locale file, add a line to `locale.go` in the `supportedLocales` map. This should be a map from the locale code to an instance of the `LocaleDetails` object you created above.
+After you've created the locale file, add a line to `locale.go` in the `SupportedLocales` map. This should be a map from the locale code to an instance of the `LocaleDetails` object you created above.
 
 Lastly, please add test cases to `locale_test.go` that test the different datetime formats, and the relative time formats.

--- a/locale.go
+++ b/locale.go
@@ -10,7 +10,8 @@ import (
 // DefaultLocaleCode is the default locale used by Goment if not set.
 const DefaultLocaleCode = "en"
 
-var supportedLocales = map[string]locales.LocaleDetails{
+// SupportedLocales exports the list of available locales.
+var SupportedLocales = map[string]locales.LocaleDetails{
 	"en": locales.EnLocale,
 	"es": locales.EsLocale,
 	"fr": locales.FrLocale,
@@ -152,7 +153,7 @@ func loadKnownLocale(localeCode string) locales.LocaleDetails {
 func loadLocale(localeCode string) (locales.LocaleDetails, error) {
 	normalizedCode := strings.ToLower(localeCode)
 
-	if locale, exist := supportedLocales[normalizedCode]; exist {
+	if locale, exist := SupportedLocales[normalizedCode]; exist {
 		return locale, nil
 	}
 


### PR DESCRIPTION
I'm currently using the awesome `golang.org/x/text/language` (see [post](https://blog.golang.org/matchlang)), for matching user locale with one of the supported languages.

```go
userLocale := "zh-TW"

// find the best matching languages, based on user locale
languagesSupportedByGoment := []language.Tag{
    language.English,
    language.French,
    language.Spanish,
}
languageMatcher := language.NewMatcher(languagesSupportedByGoment)
t, _, _ := languageMatcher.Match(language.Make(userLocale))
base, _ := t.Base()

// set the goment internal locale
g, err := goment.New(date)
g.SetLocale(base.String())
```

It would be better to expose the list of available locales in this library, to allow support for future languages.

I wonder, should we import `golang.org/x/text/language` into this module and offer an abstraction? 🤔